### PR TITLE
Fix bug when loading this library in edge

### DIFF
--- a/src/context/CastProvider.tsx
+++ b/src/context/CastProvider.tsx
@@ -72,7 +72,7 @@ const CastProvider = ({
       }
     };
 
-    if (window.cast) {
+    if (chrome.cast && window.cast) {
       window.cast.framework.CastContext.getInstance().setOptions({
         receiverApplicationId,
         resumeSavedSession,


### PR DESCRIPTION
In the new version of Microsoft Edge, `window.cast` is set, but `chrome.cast` is not. This is an issue because the chromecast library internally references `chrome.cast`. As a result, when trying to load this library in Edge, it immediately crashes. This change should preserve existing functionality, while preventing the crash in Edge.