### PR TITLE
Fix: Connection status and functionality lost on reconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     "email": "antewall@gmail.com"
   },
   "license": "MIT",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "scripts": {
     "start": "rollup -c -w",
     "test": "yarn jest",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "files": [
     "dist",
+    "src",
     "README.md"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,6 @@
     "email": "antewall@gmail.com"
   },
   "license": "MIT",
-  "files": [
-    "dist",
-    "src",
-    "README.md"
-  ],
   "scripts": {
     "start": "rollup -c -w",
     "test": "yarn jest",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "license": "MIT",
   "files": [
     "dist",
-    "src",
     "README.md"
   ],
   "scripts": {

--- a/src/context/CastProvider.tsx
+++ b/src/context/CastProvider.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
   useState,
   useMemo,
-  useCallback,
+  useCallback
 } from 'react';
 import get from 'lodash/get';
 import CastContext from './CastContext';
@@ -26,7 +26,7 @@ const CastProvider = ({
     'origin_scoped'
   ),
   language,
-  resumeSavedSession,
+  resumeSavedSession
 }: CastProviderProps) => {
   const [connected, setConnected] = useState<boolean>(false);
   const [deviceName, setDeviceName] = useState<string>('');
@@ -36,7 +36,7 @@ const CastProvider = ({
   );
   const [
     playerController,
-    setPlayerController,
+    setPlayerController
   ] = useState<cast.framework.RemotePlayerController | null>(null);
 
   useEffect(() => {
@@ -75,7 +75,7 @@ const CastProvider = ({
         receiverApplicationId,
         resumeSavedSession,
         autoJoinPolicy,
-        language,
+        language
       });
       const player = new window.cast.framework.RemotePlayer();
       setPlayer(player);
@@ -94,14 +94,15 @@ const CastProvider = ({
     language,
     receiverApplicationId,
     resetCast,
-    resumeSavedSession,
+    resumeSavedSession
   ]);
 
   useEffect(() => {
     const onConnectedChange = (
       _data: cast.framework.RemotePlayerChangedEvent
     ) => {
-      if (_data.value) {
+      if(_data.value){
+
         setConnected(true);
         const session = window.cast.framework.CastContext.getInstance().getCurrentSession();
         if (session) {
@@ -133,7 +134,7 @@ const CastProvider = ({
       initialized: castInitialized,
       deviceName,
       player,
-      playerController,
+      playerController
     };
     return value;
   }, [castInitialized, connected, deviceName, player, playerController]);

--- a/src/context/CastProvider.tsx
+++ b/src/context/CastProvider.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
   useState,
   useMemo,
-  useCallback
+  useCallback,
 } from 'react';
 import get from 'lodash/get';
 import CastContext from './CastContext';
@@ -26,7 +26,7 @@ const CastProvider = ({
     'origin_scoped'
   ),
   language,
-  resumeSavedSession
+  resumeSavedSession,
 }: CastProviderProps) => {
   const [connected, setConnected] = useState<boolean>(false);
   const [deviceName, setDeviceName] = useState<string>('');
@@ -36,7 +36,7 @@ const CastProvider = ({
   );
   const [
     playerController,
-    setPlayerController
+    setPlayerController,
   ] = useState<cast.framework.RemotePlayerController | null>(null);
 
   useEffect(() => {
@@ -48,8 +48,6 @@ const CastProvider = ({
   const resetCast = useCallback(() => {
     setConnected(false);
     setDeviceName('');
-    setPlayer(null);
-    setPlayerController(null);
   }, []);
 
   /* onCast Initalized */
@@ -77,7 +75,7 @@ const CastProvider = ({
         receiverApplicationId,
         resumeSavedSession,
         autoJoinPolicy,
-        language
+        language,
       });
       const player = new window.cast.framework.RemotePlayer();
       setPlayer(player);
@@ -96,17 +94,21 @@ const CastProvider = ({
     language,
     receiverApplicationId,
     resetCast,
-    resumeSavedSession
+    resumeSavedSession,
   ]);
 
   useEffect(() => {
     const onConnectedChange = (
       _data: cast.framework.RemotePlayerChangedEvent
     ) => {
-      setConnected(true);
-      const session = window.cast.framework.CastContext.getInstance().getCurrentSession();
-      if (session) {
-        setDeviceName(session.getSessionObj().receiver.friendlyName);
+      if (_data.value) {
+        setConnected(true);
+        const session = window.cast.framework.CastContext.getInstance().getCurrentSession();
+        if (session) {
+          setDeviceName(session.getSessionObj().receiver.friendlyName);
+        }
+      } else {
+        setConnected(false);
       }
     };
     if (playerController) {
@@ -131,7 +133,7 @@ const CastProvider = ({
       initialized: castInitialized,
       deviceName,
       player,
-      playerController
+      playerController,
     };
     return value;
   }, [castInitialized, connected, deviceName, player, playerController]);


### PR DESCRIPTION
In reference to issue #7 

This fixes a bug where when disconnecting a cast device, the Player and PlayerController is nullified, as well as the connected state always set to true whenever the event IS_CONNECTED_CHANGED happens.